### PR TITLE
ignore system process

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,10 @@ func processes() {
 	}
 	var undetermined int
 	for _, pr := range pss {
+		if pr.Pid() == 0 {
+			// ignore system process
+			continue
+		}
 		name, err := pr.Path()
 		if err != nil {
 			undetermined++


### PR DESCRIPTION
On Windows, https://github.com/keybase/go-ps return list of processes contains system process. System process ID is 0. So 

https://github.com/keybase/go-ps/blob/master/process_windows.go#L170-L172

modules always return current process if passing 0. Then gops return below.

```
0       [System Process]        (c:\dev\godev\src\github.com\google\gops\gops.exe)
1188    jvgrep.exe      (c:\dev\godev\src\github.com\mattn\jvgrep\jvgrep.exe)
17872   gops.exe        (c:\dev\godev\src\github.com\google\gops\gops.exe)
```

I'm not sure this is an issue which should be fixed in https://github.com/keybase/go-ps, however gops can ignore system process.

