### PR TITLE
Runtime vitals

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -112,6 +112,7 @@ func handle(conn net.Conn, msg []byte) error {
 		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
 		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
 		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
+		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
 	}
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,6 +108,10 @@ func handle(conn net.Conn, msg []byte) error {
 		}
 		time.Sleep(30 * time.Second)
 		pprof.StopCPUProfile()
+	case signal.Vitals:
+		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
+		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
+		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
 	}
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -110,9 +110,9 @@ func handle(conn net.Conn, msg []byte) error {
 		pprof.StopCPUProfile()
 	case signal.Vitals:
 		fmt.Fprintf(conn, "goroutines: %v\n", runtime.NumGoroutine())
+		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
 		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
 		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
-		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
 	}
 	return nil
 }

--- a/cmd.go
+++ b/cmd.go
@@ -19,6 +19,7 @@ var cmds = map[string](func(pid int) error){
 	"version":    version,
 	"pprof-heap": pprofHeap,
 	"pprof-cpu":  pprofCPU,
+	"vitals":     vitals,
 }
 
 func stackTrace(pid int) error {
@@ -94,6 +95,15 @@ func pprof(pid int, p byte) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func vitals(pid int) error {
+	out, err := cmd(pid, signal.Vitals)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(out)
+	return nil
 }
 
 func cmd(pid int, c byte) (string, error) {

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -23,4 +23,7 @@ const (
 
 	// CPUProfile starts `go tool pprof` with the current CPU profile
 	CPUProfile = byte(0x6)
+
+	// Vitals returns Go runtime statistics such as number of goroutines, GOMAXPROCS, and NumCPU.
+	Vitals = byte(0x7)
 )


### PR DESCRIPTION
This PR adds more Go runtime information such as go routine count, number of CPUs, and GOMAXPROCS.

Closes #5 