### PR TITLE
#10 replace unix socket by tcp

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -27,12 +27,9 @@ import (
 // any program on the system. Review your security requirements before
 // starting the agent.
 func Start() error {
-	gopsdir := fmt.Sprintf("%s/.gops", os.Getenv("HOME"))
-	if _, err := os.Stat(gopsdir); os.IsNotExist(err) {
-		err = os.Mkdir(gopsdir, os.ModePerm)
-		if err != nil {
-			return err
-		}
+	gopsdir, err := configdir()
+	if err != nil {
+		return err
 	}
 
 	// TODO(jbd): Expose these endpoints on HTTP. Then, we can enable
@@ -77,6 +74,17 @@ func Start() error {
 		}
 	}()
 	return err
+}
+
+func configdir() (string, error) {
+	gopsdir := fmt.Sprintf("%s/.gops", os.Getenv("HOME"))
+	if _, err := os.Stat(gopsdir); os.IsNotExist(err) {
+		err = os.Mkdir(gopsdir, os.ModePerm)
+		if err != nil {
+			return "", err
+		}
+	}
+	return gopsdir, nil
 }
 
 func handle(conn net.Conn, msg []byte) error {

--- a/cmd.go
+++ b/cmd.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/google/gops/signal"
 	ps "github.com/keybase/go-ps"
@@ -107,8 +108,14 @@ func vitals(pid int) error {
 }
 
 func cmd(pid int, c byte) (string, error) {
-	sock := fmt.Sprintf("/tmp/gops%d.sock", pid)
-	conn, err := net.Dial("unix", sock)
+	portfile := fmt.Sprintf("%s/.gops/.%d", os.Getenv("HOME"), pid)
+	b, err := ioutil.ReadFile(portfile)
+	if err != nil {
+		return "", err
+	}
+	port := strings.TrimSpace(string(b))
+	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
+
 	if err != nil {
 		return "", err
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/google/gops/agent"
 	"github.com/google/gops/signal"
 	ps "github.com/keybase/go-ps"
 )
@@ -107,8 +108,12 @@ func vitals(pid int) error {
 	return nil
 }
 
-func getport(pid int) (string, error) {
-	portfile := fmt.Sprintf("%s/.gops/.%d", os.Getenv("HOME"), pid)
+func getPort(pid int) (string, error) {
+	gopsdir, err := agent.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	portfile := fmt.Sprintf("%s/%d", gopsdir, pid)
 	b, err := ioutil.ReadFile(portfile)
 	if err != nil {
 		return "", err
@@ -118,7 +123,7 @@ func getport(pid int) (string, error) {
 }
 
 func cmd(pid int, c byte) (string, error) {
-	port, err := getport(pid)
+	port, err := getPort(pid)
 	if err != nil {
 		return "", err
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -107,15 +107,22 @@ func vitals(pid int) error {
 	return nil
 }
 
-func cmd(pid int, c byte) (string, error) {
+func getport(pid int) (string, error) {
 	portfile := fmt.Sprintf("%s/.gops/.%d", os.Getenv("HOME"), pid)
 	b, err := ioutil.ReadFile(portfile)
 	if err != nil {
 		return "", err
 	}
 	port := strings.TrimSpace(string(b))
-	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
+	return port, nil
+}
 
+func cmd(pid int, c byte) (string, error) {
+	port, err := getport(pid)
+	if err != nil {
+		return "", err
+	}
+	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Trying to build on the comment:

> I want to move off of the unix socket and want to listen on a TCP socket instead. I am planning to listen on a random port and keep the port process is listening under $HOME/.gops/.addr. This will also enable the windows support.

Not sure about the perms, though.