### PR TITLE
fix typo in README and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ gops pprof-cpu -p=<PID>
 To enter the heap profile, run:
 
 ```sh
-$ gops pprof-mem -p=<PID>
+$ gops pprof-heap -p=<PID>
 ```
 
 #### 4.  gc

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ Commands:
     vitals      Prints the runtime stats.
 
     pprof-heap  Reads the heap profile and launches "go tool pprof".
-    pprof-mem   Reads the CPU profile and launches "go tool pprof".
+    pprof-cpu   Reads the CPU profile and launches "go tool pprof".
 
     help        Prints this help text.
 


### PR DESCRIPTION
pprof-mem is invalid command, some of them mixed up with pprof-heap & pprof-cpu in README & flag usage