### PR TITLE
Allow starting the agent without installing a signal handler

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package agent
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestListen(t *testing.T) {
+	err := Listen()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentListen(t *testing.T) {
+	err := Listen(func(opts *AgentOptions) {
+		opts.HandleSignals = false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if globalAgent.options.HandleSignals {
+		t.Fatal("expected HandleSignals to be false")
+	}
+	portfile := globalAgent.portfile
+	listener := globalAgent.listener
+	portdata, err := ioutil.ReadFile(portfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(portdata) == 0 || !strings.HasSuffix(listener.Addr().String(), string(portdata)) {
+		t.Fatalf("expected portdata to have listened port, got: %q", string(portdata))
+	}
+}
+
+func TestAgentClose(t *testing.T) {
+	err := Listen(func(opts *AgentOptions) {
+		opts.HandleSignals = false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	portfile := globalAgent.portfile
+	listener := globalAgent.listener
+	Close()
+	_, err = os.Stat(portfile)
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected portfile not to exist, got error: %v", err)
+	}
+	if globalAgent.portfile != "" {
+		t.Fatalf("expected portfile in agent to be empty, got: %q", globalAgent.portfile)
+	}
+	err = listener.Close()
+	if err == nil || !strings.HasSuffix(err.Error(), "use of closed network connection") {
+		t.Fatalf("expected listener not to closed, got error: %v", err)
+	}
+	if globalAgent.listener != nil {
+		t.Fatalf("expected listener in agent to be nil, got: %#v", globalAgent.listener)
+	}
+}
+
+func TestAgentListenMultipleClose(t *testing.T) {
+	err := Listen(func(opts *AgentOptions) {
+		opts.HandleSignals = false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	Close()
+	Close()
+	Close()
+	Close()
+}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	if err := agent.Start(); err != nil {
+	if err := agent.Listen(); err != nil {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Hour)


### PR DESCRIPTION
If the application the agent is being installed on also need to run some shutdown code during an Interrupt signal, it's important to have the ability to prevent gops agent from calling os.Exit(). This also adds the requirement of exposing a method to manually cleanup garbage left by the gops agent.

To allow custom agent flags now and in the future an Agent type was created with a public boolean field HandleSignals. This allowed preserving the current interface by having the Start() method start an Agent with HandleSignals set to true. The Agent type also exposes a Stop() method to perform the necessary cleanup.

This PR also adds some basic initial testing to Agent start and stopping.