### PR TITLE
agent: prettier formatting for units printed by memstats

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ package agent
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -28,6 +29,8 @@ var (
 	mu       sync.Mutex
 	portfile string
 	listener net.Listener
+
+	units = []string{" bytes", "KB", "MB", "GB", "TB", "PB"}
 )
 
 // Options allows configuring the started agent.
@@ -143,7 +146,22 @@ func Close() {
 	}
 }
 
-func handle(conn net.Conn, msg []byte) error {
+func formatBytes(val uint64) string {
+	var i int
+	var target uint64
+	for i = range units {
+		target = 1 << uint(10*(i+1))
+		if val < target {
+			break
+		}
+	}
+	if i > 0 {
+		return fmt.Sprintf("%0.2f%s (%d bytes)", float64(val)/(float64(target)/1024), units[i], val)
+	}
+	return fmt.Sprintf("%d bytes", val)
+}
+
+func handle(conn io.Writer, msg []byte) error {
 	switch msg[0] {
 	case signal.StackTrace:
 		buf := make([]byte, 1<<16)
@@ -157,23 +175,27 @@ func handle(conn net.Conn, msg []byte) error {
 	case signal.MemStats:
 		var s runtime.MemStats
 		runtime.ReadMemStats(&s)
-		fmt.Fprintf(conn, "alloc: %v bytes\n", s.Alloc)
-		fmt.Fprintf(conn, "total-alloc: %v bytes\n", s.TotalAlloc)
-		fmt.Fprintf(conn, "sys: %v bytes\n", s.Sys)
+		fmt.Fprintf(conn, "alloc: %v\n", formatBytes(s.Alloc))
+		fmt.Fprintf(conn, "total-alloc: %v\n", formatBytes(s.TotalAlloc))
+		fmt.Fprintf(conn, "sys: %v\n", formatBytes(s.Sys))
 		fmt.Fprintf(conn, "lookups: %v\n", s.Lookups)
 		fmt.Fprintf(conn, "mallocs: %v\n", s.Mallocs)
 		fmt.Fprintf(conn, "frees: %v\n", s.Frees)
-		fmt.Fprintf(conn, "heap-alloc: %v bytes\n", s.HeapAlloc)
-		fmt.Fprintf(conn, "heap-sys: %v bytes\n", s.HeapSys)
-		fmt.Fprintf(conn, "heap-idle: %v bytes\n", s.HeapIdle)
-		fmt.Fprintf(conn, "heap-in-use: %v bytes\n", s.HeapInuse)
-		fmt.Fprintf(conn, "heap-released: %v bytes\n", s.HeapReleased)
+		fmt.Fprintf(conn, "heap-alloc: %v\n", formatBytes(s.HeapAlloc))
+		fmt.Fprintf(conn, "heap-sys: %v\n", formatBytes(s.HeapSys))
+		fmt.Fprintf(conn, "heap-idle: %v\n", formatBytes(s.HeapIdle))
+		fmt.Fprintf(conn, "heap-in-use: %v\n", formatBytes(s.HeapInuse))
+		fmt.Fprintf(conn, "heap-released: %v\n", formatBytes(s.HeapReleased))
 		fmt.Fprintf(conn, "heap-objects: %v\n", s.HeapObjects)
-		fmt.Fprintf(conn, "stack-in-use: %v bytes\n", s.StackInuse)
-		fmt.Fprintf(conn, "stack-sys: %v bytes\n", s.StackSys)
-		fmt.Fprintf(conn, "next-gc: when heap-alloc >= %v bytes\n", s.NextGC)
-		fmt.Fprintf(conn, "last-gc: %v ns\n", s.LastGC)
-		fmt.Fprintf(conn, "gc-pause: %v ns\n", s.PauseTotalNs)
+		fmt.Fprintf(conn, "stack-in-use: %v\n", formatBytes(s.StackInuse))
+		fmt.Fprintf(conn, "stack-sys: %v\n", formatBytes(s.StackSys))
+		fmt.Fprintf(conn, "next-gc: when heap-alloc >= %v\n", formatBytes(s.NextGC))
+		lastGC := "-"
+		if s.LastGC != 0 {
+			lastGC = fmt.Sprint(time.Unix(0, int64(s.LastGC)))
+		}
+		fmt.Fprintf(conn, "last-gc: %v\n", lastGC)
+		fmt.Fprintf(conn, "gc-pause: %v\n", time.Duration(s.PauseTotalNs))
 		fmt.Fprintf(conn, "num-gc: %v\n", s.NumGC)
 		fmt.Fprintf(conn, "enable-gc: %v\n", s.EnableGC)
 		fmt.Fprintf(conn, "debug-gc: %v\n", s.DebugGC)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -42,3 +42,26 @@ func TestAgentListenMultipleClose(t *testing.T) {
 	Close()
 	Close()
 }
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		val  uint64
+		want string
+	}{
+		{1023, "1023 bytes"},
+		{1024, "1.00KB (1024 bytes)"},
+		{1024*1024 - 100, "1023.90KB (1048476 bytes)"},
+		{1024 * 1024, "1.00MB (1048576 bytes)"},
+		{1024 * 1025, "1.00MB (1049600 bytes)"},
+		{1024 * 1024 * 1024, "1.00GB (1073741824 bytes)"},
+		{1024*1024*1024 + 430*1024*1024, "1.42GB (1524629504 bytes)"},
+		{1024 * 1024 * 1024 * 1024 * 1024, "1.00PB (1125899906842624 bytes)"},
+		{1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1024.00PB (1152921504606846976 bytes)"},
+	}
+	for _, tt := range tests {
+		result := formatBytes(tt.val)
+		if result != tt.want {
+			t.Errorf("formatBytes(%v) = %q; want %q", tt.val, result, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
I'm not sure if this is wanted of not but decided to give it a try, please feel free to dump this if this change isn't wanted. :)

The output from memstats with these changes look like:

```
alloc: 3MB (3283704 bytes)
total-alloc: 7GB (7826209192 bytes)
sys: 8MB (8427768 bytes)
lookups: 7
mallocs: 16170
frees: 15572
heap-alloc: 3MB (3283704 bytes)
heap-sys: 4MB (4784128 bytes)
heap-idle: 1MB (1073152 bytes)
heap-in-use: 3MB (3710976 bytes)
heap-released: 0 bytes
heap-objects: 598
stack-in-use: 448KB (458752 bytes)
stack-sys: 448KB (458752 bytes)
next-gc: when heap-alloc >= 4MB (4194304 bytes)
last-gc: 2017-01-10 16:11:10.912477567 -0200 BRST
gc-pause: 59.760994ms
num-gc: 1865
enable-gc: true
debug-gc: false
```
