### PR TITLE
Added remote mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ func main() {
 
 ### Diagnostics manual
 
-#### 0. listing all processes
+It is possible to use gops tool both in local and remote mode.
+
+Local mode requires that you start the target binary as the same user that runs gops binary.
+To use gops in a remote mode you need to know target binary's agent's host and port.
+
+In Local mode use process's PID as a `<target>`; in Remote mode `<target>` is `host:port` combination.
+
+#### 0. listing all processes running locally
 
 To print all go processes, run `gops` without arguments:
 
@@ -63,7 +70,7 @@ Note that processes running the agent are marked with `*` next to the PID (e.g. 
 In order to print the current stack trace from a target program, run the following command:
 
 ```sh
-$ gops stack <pid>
+$ gops stack <target>
 ```
 
 #### 2. memstats
@@ -71,7 +78,7 @@ $ gops stack <pid>
 To print the current memory stats, run the following command:
 
 ```sh
-$ gops memstats <pid>
+$ gops memstats <target>
 ```
 
 #### 3. pprof
@@ -82,13 +89,13 @@ it shells out to the `go tool pprof` and let you interatively examine the profil
 To enter the CPU profile, run:
 
 ```sh
-$ gops pprof-cpu <pid>
+$ gops pprof-cpu <target>
 ```
 
 To enter the heap profile, run:
 
 ```sh
-$ gops pprof-heap <pid>
+$ gops pprof-heap <target>
 ```
 
 #### 4.  gc
@@ -97,7 +104,7 @@ If you want to force run garbage collection on the target program, run the follo
 It will block until the GC is completed.
 
 ```sh
-$ gops gc <pid>
+$ gops gc <target>
 ```
 
 #### 5. version
@@ -105,7 +112,7 @@ $ gops gc <pid>
 gops reports the Go version the target program is built with, if you run the following:
 
 ```sh
-$ gops version <pid>
+$ gops version <target>
 ```
 
 #### 6. stats
@@ -113,5 +120,5 @@ $ gops version <pid>
 To print the runtime statistics such as number of goroutines and `GOMAXPROCS`, run the following:
 
 ```sh
-$ gops stats <pid>
+$ gops stats <target>
 ```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ func main() {
 It is possible to use gops tool both in local and remote mode.
 
 Local mode requires that you start the target binary as the same user that runs gops binary.
-To use gops in a remote mode you need to know target binary's agent's host and port.
+To use gops in a remote mode you need to know target's agent address.
 
-In Local mode use process's PID as a `<target>`; in Remote mode `<target>` is `host:port` combination.
+In Local mode use process's PID as a target; in Remote mode target is a `host:port` combination.
 
 #### 0. Listing all processes running locally
 
@@ -65,13 +65,13 @@ $ gops
 
 Note that processes running the agent are marked with `*` next to the PID (e.g. `4132*`).
 
-#### $ gops stack \<target\>
+#### $ gops stack (\<pid\>|\<addr\>)
 
 In order to print the current stack trace from a target program, run the following command:
 
 
 ```sh
-$ gops stack <target>
+$ gops stack (<pid>|<addr>)
 gops stack 85709
 goroutine 8 [running]:
 runtime/pprof.writeGoroutineStacks(0x13c7bc0, 0xc42000e008, 0xc420ec8520, 0xc420ec8520)
@@ -89,31 +89,31 @@ created by github.com/google/gops/agent.Listen
 # ...
 ```
 
-#### $ gops memstats \<target\>
+#### $ gops memstats (\<pid\>|\<addr\>)
 
 To print the current memory stats, run the following command:
 
 ```sh
-$ gops memstats <target>
+$ gops memstats (<pid>|<addr>)
 ```
 
 
-#### $ gops gc \<target\>
+#### $ gops gc (\<pid\>|\<addr\>)
 
 If you want to force run garbage collection on the target program, run `gc`.
 It will block until the GC is completed.
 
 
-#### $ gops version \<target\>
+#### $ gops version (\<pid\>|\<addr\>)
 
 gops reports the Go version the target program is built with, if you run the following:
 
 ```sh
-$ gops version <target>
+$ gops version (<pid>|<addr>)
 devel +6a3c6c0 Sat Jan 14 05:57:07 2017 +0000
 ```
 
-#### $ gops stats \<target\>
+#### $ gops stats (\<pid\>|\<addr\>)
 
 To print the runtime statistics such as number of goroutines and `GOMAXPROCS`.
 
@@ -128,13 +128,13 @@ it shells out to the `go tool pprof` and let you interatively examine the profil
 To enter the CPU profile, run:
 
 ```sh
-$ gops pprof-cpu <target>
+$ gops pprof-cpu (<pid>|<addr>)
 ```
 
 To enter the heap profile, run:
 
 ```sh
-$ gops pprof-heap <target>
+$ gops pprof-heap (<pid>|<addr>)
 ```
 
 ##### Go execution trace
@@ -142,6 +142,6 @@ $ gops pprof-heap <target>
 gops allows you to start the runtime tracer for 5 seconds and examine the results.
 
 ```sh
-$ gops trace <target>
+$ gops trace (<pid>|<addr>)
 ```
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,8 +18,11 @@ import (
 	"sync"
 	"time"
 
+	"bufio"
+
 	"github.com/google/gops/internal"
 	"github.com/google/gops/signal"
+	"github.com/kardianos/osext"
 )
 
 const defaultAddr = "127.0.0.1:0"
@@ -189,6 +192,19 @@ func handle(conn net.Conn, msg []byte) error {
 		fmt.Fprintf(conn, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
 		fmt.Fprintf(conn, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
 		fmt.Fprintf(conn, "num CPU: %v\n", runtime.NumCPU())
+	case signal.BinaryDump:
+		path, err := osext.Executable()
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = bufio.NewReader(f).WriteTo(conn)
+		return err
 	}
 	return nil
 }

--- a/cmd.go
+++ b/cmd.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/google/gops/internal"
 	"github.com/google/gops/signal"
-	ps "github.com/keybase/go-ps"
+	"github.com/pkg/errors"
 )
 
-var cmds = map[string](func(pid int) error){
+var cmds = map[string](func(target string) error){
 	"stack":      stackTrace,
 	"gc":         gc,
 	"memstats":   memStats,
@@ -23,58 +24,79 @@ var cmds = map[string](func(pid int) error){
 	"stats":      stats,
 }
 
-func stackTrace(pid int) error {
-	return cmdWithPrint(pid, signal.StackTrace)
+func stackTrace(target string) error {
+	return cmdWithPrint(target, signal.StackTrace)
 }
 
-func gc(pid int) error {
-	_, err := cmd(pid, signal.GC)
+func gc(target string) error {
+	addr, err := targetToAddr(target)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't parse target's string to addr")
+	}
+	_, err = cmd(*addr, signal.GC)
 	return err
 }
 
-func memStats(pid int) error {
-	return cmdWithPrint(pid, signal.MemStats)
+func memStats(target string) error {
+	return cmdWithPrint(target, signal.MemStats)
 }
 
-func version(pid int) error {
-	return cmdWithPrint(pid, signal.Version)
+func version(target string) error {
+	return cmdWithPrint(target, signal.Version)
 }
 
-func pprofHeap(pid int) error {
-	return pprof(pid, signal.HeapProfile)
+func pprofHeap(target string) error {
+	return pprof(target, signal.HeapProfile)
 }
 
-func pprofCPU(pid int) error {
+func pprofCPU(target string) error {
 	fmt.Println("Profiling CPU now, will take 30 secs...")
-	return pprof(pid, signal.CPUProfile)
+	return pprof(target, signal.CPUProfile)
 }
 
-func pprof(pid int, p byte) error {
-	out, err := cmd(pid, p)
+func pprof(target string, p byte) error {
+	addr, err := targetToAddr(target)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't parse target's string to addr")
+	}
+
+	tmpDumpFile, err := ioutil.TempFile("", "profile")
 	if err != nil {
 		return err
 	}
-	if len(out) == 0 {
-		return errors.New("failed to read the profile")
+	{
+		out, err := cmd(*addr, p)
+		if err != nil {
+			return err
+		}
+		if len(out) == 0 {
+			return errors.New("failed to read the profile")
+		}
+		defer os.Remove(tmpDumpFile.Name())
+		if err := ioutil.WriteFile(tmpDumpFile.Name(), out, 0); err != nil {
+			return err
+		}
 	}
-	tmpfile, err := ioutil.TempFile("", "profile")
+	// Download running binary
+	tmpBinFile, err := ioutil.TempFile("", "binary")
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), out, 0); err != nil {
-		return err
+	{
+
+		out, err := cmd(*addr, signal.BinaryDump)
+		if err != nil {
+			return errors.New("Couldn't retrieve running binary's dump")
+		}
+		if len(out) == 0 {
+			return errors.New("failed to read the binary")
+		}
+		defer os.Remove(tmpBinFile.Name())
+		if err := ioutil.WriteFile(tmpBinFile.Name(), out, 0); err != nil {
+			return err
+		}
 	}
-	process, err := ps.FindProcess(pid)
-	if err != nil {
-		// TODO(jbd): add context to the error
-		return err
-	}
-	binary, err := process.Path()
-	if err != nil {
-		return fmt.Errorf("cannot the binary for the PID: %v", err)
-	}
-	cmd := exec.Command("go", "tool", "pprof", binary, tmpfile.Name())
+	cmd := exec.Command("go", "tool", "pprof", tmpBinFile.Name(), tmpDumpFile.Name())
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -82,12 +104,16 @@ func pprof(pid int, p byte) error {
 	return cmd.Run()
 }
 
-func stats(pid int) error {
-	return cmdWithPrint(pid, signal.Stats)
+func stats(target string) error {
+	return cmdWithPrint(target, signal.Stats)
 }
 
-func cmdWithPrint(pid int, c byte) error {
-	out, err := cmd(pid, c)
+func cmdWithPrint(target string, c byte) error {
+	addr, err := targetToAddr(target)
+	if err != nil {
+		return errors.Wrap(err, "Couldn't parse target's string to addr")
+	}
+	out, err := cmd(*addr, c)
 	if err != nil {
 		return err
 	}
@@ -95,12 +121,33 @@ func cmdWithPrint(pid int, c byte) error {
 	return nil
 }
 
-func cmd(pid int, c byte) ([]byte, error) {
+// targetToAddr tries to parse the target string, be it remote host:port
+// or local process's PID.
+func targetToAddr(target string) (*net.TCPAddr, error) {
+	if strings.Index(target, ":") != -1 {
+		// addr host:port passed
+		var err error
+		addr, err := net.ResolveTCPAddr("tcp", target)
+		if err != nil {
+			return nil, errors.Wrap(err, "Couldn't parse dst address")
+		}
+		return addr, nil
+	}
+	// try to find port by pid then, connect to local
+	pid, err := strconv.Atoi(target)
+	if err != nil {
+		return nil, errors.Wrap(err, "Couldn't parse PID")
+	}
 	port, err := internal.GetPort(pid)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Couldn't get port by PID")
 	}
-	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
+	addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:"+port)
+	return addr, nil
+}
+
+func cmd(addr net.TCPAddr, c byte) ([]byte, error) {
+	conn, err := net.DialTCP("tcp", nil, &addr)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -12,7 +12,9 @@ import (
 )
 
 func main() {
-	if err := agent.Listen(nil); err != nil {
+	if err := agent.Listen(&agent.Options{
+		Addr: "127.0.0.1:4321",
+	}); err != nil {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Hour)

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/google/gops/internal/objfile"
@@ -19,8 +18,6 @@ import (
 
 const helpText = `Usage: gops is a tool to list and diagnose Go processes.
 
-    gops             Lists all Go processes currently running.
-    gops cmd <pid>   See the commands below.
 
 Commands:
     gc          Runs the garbage collector and blocks until successful.
@@ -51,17 +48,13 @@ func main() {
 		usage("")
 	}
 	if len(os.Args) < 3 {
-		usage("missing PID")
-	}
-	pid, err := strconv.Atoi(os.Args[2])
-	if err != nil {
-		usage("PID should be numeric")
+		usage("missing PID or host:port combo")
 	}
 	fn, ok := cmds[cmd]
 	if !ok {
 		usage("unknown subcommand")
 	}
-	if err := fn(pid); err != nil {
+	if err := fn(os.Args[2]); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -50,13 +50,18 @@ func main() {
 		usage("")
 	}
 	if len(os.Args) < 3 {
-		usage("missing PID or host:port combo")
+		usage("missing PID or address")
 	}
 	fn, ok := cmds[cmd]
 	if !ok {
 		usage("unknown subcommand")
 	}
-	if err := fn(os.Args[2]); err != nil {
+	addr, err := targetToAddr(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't resolve addr or pid %v to TCPAddress: %v\n", os.Args[2], err)
+		os.Exit(1)
+	}
+	if err := fn(*addr); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -26,4 +26,7 @@ const (
 
 	// Stats returns Go runtime statistics such as number of goroutines, GOMAXPROCS, and NumCPU.
 	Stats = byte(0x7)
+
+	// BinaryDump returns running binary file.
+	BinaryDump = byte(0x8)
 )


### PR DESCRIPTION
This PR adds a possibility to use this tool for instrumented binaries running on remote hosts.

PR adds new protocol command, which dumps running service's binary file. Two dependencies were added, namely github.com/pkg/errors for errors' contexts and github.com/kardianos/osext, which helps agent find the path to executable file.

Interface changes are simple: it is now possible to pass `host:port` combo instead of `PID` to gops tool.