### PR TITLE
gops cmd and agent now speaking HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is possible to use gops tool both in local and remote mode.
 Local mode requires that you start the target binary as the same user that runs gops binary.
 To use gops in a remote mode you need to know target's agent address.
 
-In Local mode use process's PID as a target; in Remote mode target is a `host:port` combination.
+In Local mode use process's PID as a target; in Remote mode target is a URL `http://host:port/[path]`.
 
 #### 0. Listing all processes running locally
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -7,6 +7,8 @@ package agent
 import (
 	"os"
 	"testing"
+
+	"github.com/google/gops/internal"
 )
 
 func TestListen(t *testing.T) {
@@ -23,12 +25,11 @@ func TestAgentClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	Close()
+
+	portfile, _ := internal.PIDFile(os.Getpid())
 	_, err = os.Stat(portfile)
 	if !os.IsNotExist(err) {
 		t.Fatalf("portfile = %q doesn't exist; err = %v", portfile, err)
-	}
-	if portfile != "" {
-		t.Fatalf("got = %q; want empty portfile", portfile)
 	}
 }
 

--- a/agent/close.go
+++ b/agent/close.go
@@ -1,0 +1,23 @@
+// +build !go1.8
+
+package agent
+
+import (
+	"github.com/google/gops/internal"
+	"os"
+)
+
+// Close closes the agent, removing temporary files and closing the http.Server.
+// If no agent is listening, Close does nothing.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile, err := internal.PIDFile(os.Getpid()); err == nil {
+		os.Remove(portfile)
+	}
+
+	if listener != nil {
+		listener.Close()
+	}
+}

--- a/agent/close_go1.8.go
+++ b/agent/close_go1.8.go
@@ -1,0 +1,28 @@
+// +build go1.8
+
+package agent
+
+import (
+	"context"
+	"github.com/google/gops/internal"
+	"os"
+	"time"
+)
+
+// Close closes the agent, removing temporary files and closing the http.Server using Shutdown method.
+// If no agent is listening, Close does nothing.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if portfile, err := internal.PIDFile(os.Getpid()); err == nil {
+		os.Remove(portfile)
+	}
+
+	if server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		server.Shutdown(ctx)
+		server.Close()
+	}
+}

--- a/examples/path/main.go
+++ b/examples/path/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/google/gops/agent"
+)
+
+func main() {
+	http.Handle("/path", &agent.Agent{})
+	http.ListenAndServe(":4321", nil)
+	// this syntax will enable
+	// gops trace http://localhost:4321/path
+}

--- a/main.go
+++ b/main.go
@@ -58,10 +58,10 @@ func main() {
 	}
 	addr, err := targetToAddr(os.Args[2])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Couldn't resolve addr or pid %v to TCPAddress: %v\n", os.Args[2], err)
+		fmt.Fprintf(os.Stderr, "Couldn't resolve addr or pid %v to HTTP request address: %v\n", os.Args[2], err)
 		os.Exit(1)
 	}
-	if err := fn(*addr); err != nil {
+	if err := fn(addr); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -5,6 +5,10 @@
 // Package signal contains signals used to communicate to the gops agents.
 package signal
 
+import (
+	"encoding/json"
+)
+
 const (
 	// StackTrace represents a command to print stack trace.
 	StackTrace = byte(0x1)
@@ -33,3 +37,9 @@ const (
 	// BinaryDump returns running binary file.
 	BinaryDump = byte(0x9)
 )
+
+// Command with Flags defined base on code
+type Command struct {
+	Code  byte
+	Flags json.RawMessage
+}


### PR DESCRIPTION
This pull request make gops cmd and agent talk in HTTP by doing these:
 - Wrapper for signal (as Command) for json encoding (I need this for complex payload like custom flag for pprof-cpu time).
 - If user decided to use Agent http handler (rather than agent.Listen shortcut function) then the target:
```gops trace http://localhost:4321/path```
 - If using agent.Listen function, user unable to specific the "path".