### PR TITLE
Another take on HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ func main() {
 It is possible to use gops tool both in local and remote mode.
 
 Local mode requires that you start the target binary as the same user that runs gops binary.
-To use gops in a remote mode you need to know target's agent address.
+To use gops in a remote mode you need to know target's agent address (and HTTP endpoint if using HTTP listener).
 
-In Local mode use process's PID as a target; in Remote mode target is a `host:port` combination.
+In Local mode use process's PID as a target; in Remote mode target is a `host:port` combination or HTTP addr (`http://host:port/handler`).
 
 #### 0. Listing all processes running locally
 
@@ -65,13 +65,13 @@ $ gops
 
 Note that processes running the agent are marked with `*` next to the PID (e.g. `4132*`).
 
-#### $ gops stack (\<pid\>|\<addr\>)
+#### $ gops stack (\<pid\>|\<addr\>|\<endpoint\>)
 
 In order to print the current stack trace from a target program, run the following command:
 
 
 ```sh
-$ gops stack (<pid>|<addr>)
+$ gops stack (<pid>|<addr>|<endpoint>)
 gops stack 85709
 goroutine 8 [running]:
 runtime/pprof.writeGoroutineStacks(0x13c7bc0, 0xc42000e008, 0xc420ec8520, 0xc420ec8520)
@@ -89,31 +89,31 @@ created by github.com/google/gops/agent.Listen
 # ...
 ```
 
-#### $ gops memstats (\<pid\>|\<addr\>)
+#### $ gops memstats (\<pid\>|\<addr\>|\<endpoint\>)
 
 To print the current memory stats, run the following command:
 
 ```sh
-$ gops memstats (<pid>|<addr>)
+$ gops memstats (<pid>|<addr>|<endpoint>)
 ```
 
 
-#### $ gops gc (\<pid\>|\<addr\>)
+#### $ gops gc (\<pid\>|\<addr\>|\<endpoint\>)
 
 If you want to force run garbage collection on the target program, run `gc`.
 It will block until the GC is completed.
 
 
-#### $ gops version (\<pid\>|\<addr\>)
+#### $ gops version (\<pid\>|\<addr\>|\<endpoint\>)
 
 gops reports the Go version the target program is built with, if you run the following:
 
 ```sh
-$ gops version (<pid>|<addr>)
+$ gops version (<pid>|<addr>|<endpoint>)
 devel +6a3c6c0 Sat Jan 14 05:57:07 2017 +0000
 ```
 
-#### $ gops stats (\<pid\>|\<addr\>)
+#### $ gops stats (\<pid\>|\<addr\>|\<endpoint\>)
 
 To print the runtime statistics such as number of goroutines and `GOMAXPROCS`.
 
@@ -128,13 +128,13 @@ it shells out to the `go tool pprof` and let you interatively examine the profil
 To enter the CPU profile, run:
 
 ```sh
-$ gops pprof-cpu (<pid>|<addr>)
+$ gops pprof-cpu (<pid>|<addr>|<endpoint>)
 ```
 
 To enter the heap profile, run:
 
 ```sh
-$ gops pprof-heap (<pid>|<addr>)
+$ gops pprof-heap (<pid>|<addr>|<endpoint>)
 ```
 
 ##### Execution trace
@@ -142,6 +142,6 @@ $ gops pprof-heap (<pid>|<addr>)
 gops allows you to start the runtime tracer for 5 seconds and examine the results.
 
 ```sh
-$ gops trace (<pid>|<addr>)
+$ gops trace (<pid>|<addr>|<endpoint>)
 ```
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -116,7 +116,7 @@ func listen() {
 			fmt.Fprintf(os.Stderr, "gops: %v", err)
 			continue
 		}
-		if err := handle(fd, buf); err != nil {
+		if err := handle(fd, buf[0]); err != nil {
 			fmt.Fprintf(os.Stderr, "gops: %v", err)
 			continue
 		}
@@ -165,8 +165,8 @@ func formatBytes(val uint64) string {
 	return fmt.Sprintf("%d bytes", val)
 }
 
-func handle(conn io.Writer, msg []byte) error {
-	switch msg[0] {
+func handle(conn io.Writer, msg byte) error {
+	switch msg {
 	case signal.StackTrace:
 		return pprof.Lookup("goroutine").WriteTo(conn, 2)
 	case signal.GC:

--- a/agent/http.go
+++ b/agent/http.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"net/http"
+
+	"github.com/google/gops/signal"
+)
+
+// HandlerFunc returns a function that handles gops requests over HTTP.
+func HandlerFunc() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sig, ok := signal.FromParam(r.URL.Query().Get("action"))
+		if !ok {
+			w.WriteHeader(400)
+			_, _ = w.Write([]byte("Unknown action!"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		handle(w, sig)
+	}
+}

--- a/agent/http.go
+++ b/agent/http.go
@@ -16,6 +16,10 @@ func HandlerFunc() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
-		handle(w, sig)
+		err := handle(w, sig)
+		if err != nil {
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(err.Error()))
+		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"net/url"
+
+	"github.com/google/gops/signal"
+	"github.com/pkg/errors"
+)
+
+type Client interface {
+	Run(byte) ([]byte, error)
+	RunReader(byte) (io.ReadCloser, error)
+}
+
+type ClientTCP struct {
+	addr net.TCPAddr
+}
+
+func (c *ClientTCP) Run(sig byte) ([]byte, error) {
+	return c.run(sig)
+}
+
+func (c *ClientTCP) RunReader(sig byte) (io.ReadCloser, error) {
+	return c.runLazy(sig)
+}
+
+func (c *ClientTCP) runLazy(sig byte) (io.ReadCloser, error) {
+	conn, err := net.DialTCP("tcp", nil, &c.addr)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := conn.Write([]byte{sig}); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *ClientTCP) run(sig byte) ([]byte, error) {
+	r, err := c.runLazy(sig)
+	defer r.Close()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(r)
+}
+
+type ClientHTTP struct {
+	baseAddr string
+}
+
+func (c *ClientHTTP) Run(sig byte) ([]byte, error) {
+	r, err := c.RunReader(sig)
+	defer r.Close()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(r)
+}
+
+func (c *ClientHTTP) RunReader(sig byte) (io.ReadCloser, error) {
+	action, ok := signal.ToParam(sig)
+	if !ok {
+		return nil, fmt.Errorf("unknown signal %v", sig)
+	}
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	u, err := url.Parse(c.baseAddr)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't parse dest URI")
+	}
+	u.Query().Add("action", action)
+
+	rsp, err := client.Get(u.String())
+	if err != nil {
+		return nil, errors.Wrap(err, "error when making HTTP call")
+	}
+	return rsp.Body, nil
+}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -21,14 +21,17 @@ import (
 )
 
 func main() {
+	// Do work in parallel
+	go doWork()
 
+	// Serve HTTP handler to be available in HTTP mode
 	l, err := net.Listen("tcp", "127.0.0.1:12345")
 	if err != nil {
 		log.Fatal(err)
 	}
-	go doWork()
 	go http.Serve(l, agent.HandlerFunc())
 
+	// Use raw socket to accept connections
 	if err := agent.Listen(nil); err != nil {
 		log.Fatal(err)
 	}
@@ -36,7 +39,7 @@ func main() {
 }
 
 func doWork() {
-	// Emulate some work for non-empty profile
+	// Emulate some work for non-empty profile)
 	for i := 0; ; i++ {
 		res := math.Log(float64(i))
 		ioutil.Discard.Write([]byte(fmt.Sprint(res)))

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -5,15 +5,41 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"time"
+
+	"net/http"
+
+	"net"
+
+	"math"
+
+	"io/ioutil"
 
 	"github.com/google/gops/agent"
 )
 
 func main() {
+
+	l, err := net.Listen("tcp", "127.0.0.1:12345")
+	if err != nil {
+		log.Fatal(err)
+	}
+	go doWork()
+	go http.Serve(l, agent.HandlerFunc())
+
 	if err := agent.Listen(nil); err != nil {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Hour)
+}
+
+func doWork() {
+	// Emulate some work for non-empty profile
+	for i := 0; ; i++ {
+		res := math.Log(float64(i))
+		ioutil.Discard.Write([]byte(fmt.Sprint(res)))
+		<-time.After(time.Millisecond * 50)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -56,12 +56,12 @@ func main() {
 	if !ok {
 		usage("unknown subcommand")
 	}
-	addr, err := targetToAddr(os.Args[2])
+	cli, err := targetToClient(os.Args[2])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't resolve addr or pid %v to TCPAddress: %v\n", os.Args[2], err)
 		os.Exit(1)
 	}
-	if err := fn(*addr); err != nil {
+	if err := fn(cli); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -33,3 +33,40 @@ const (
 	// BinaryDump returns running binary file.
 	BinaryDump = byte(0x9)
 )
+
+// httpPathToSignal maps HTTP request param values to signals.
+var httpPathToSignal = map[string]byte{
+	"stacktrace": StackTrace,
+	"gc":         GC,
+	"memstats":   MemStats,
+	"version":    Version,
+	"prof-heap":  HeapProfile,
+	"prof-cpu":   CPUProfile,
+	"stats":      Stats,
+	"trace":      Trace,
+	"binary":     BinaryDump,
+}
+
+// toHTTPPath maps signals to HTTP request params.
+var toHTTPPath = map[byte]string{}
+
+func init() {
+	// Fill second lookup map from first
+	for k, v := range httpPathToSignal {
+		toHTTPPath[v] = k
+	}
+}
+
+// ToParam returns HTTP param associated with given signal.
+// Boolean is false if signal was not found.
+func ToParam(sig byte) (string, bool) {
+	ret, ok := toHTTPPath[sig]
+	return ret, ok
+}
+
+// FromParam returns signal associated with given HTTP parameter.
+// Boolean is false if signal was not found.
+func FromParam(param string) (byte, bool) {
+	ret, ok := httpPathToSignal[param]
+	return ret, ok
+}


### PR DESCRIPTION
This PR adds communication over HTTP, so it would be possible to use existing server to serve gops traffic. All previous modes are preserved as-is; so both local and rawsocket-remote modes are still there.

I've refactored client code a bit so that both socket and HTTP modes would be possible to use; now there's a `Client` iface implemented by `ClientTCP` and `ClientHTTP` that is passed to every gops command's function instead of raw `TCPAddr`.

To use it run gops like this: `gops pprof-cpu http://localhost:port/handler`