### PR TITLE
remove version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,6 @@ If you want to force run garbage collection on the target program, run `gc`.
 It will block until the GC is completed.
 
 
-#### $ gops version (\<pid\>|\<addr\>)
-
-gops reports the Go version the target program is built with, if you run the following:
-
-```sh
-$ gops version (<pid>|<addr>)
-devel +6a3c6c0 Sat Jan 14 05:57:07 2017 +0000
-```
-
 #### $ gops stats (\<pid\>|\<addr\>)
 
 To print the runtime statistics such as number of goroutines and `GOMAXPROCS`.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -200,8 +200,6 @@ func handle(conn io.Writer, msg []byte) error {
 		fmt.Fprintf(conn, "num-gc: %v\n", s.NumGC)
 		fmt.Fprintf(conn, "enable-gc: %v\n", s.EnableGC)
 		fmt.Fprintf(conn, "debug-gc: %v\n", s.DebugGC)
-	case signal.Version:
-		fmt.Fprintf(conn, "%v\n", runtime.Version())
 	case signal.HeapProfile:
 		pprof.WriteHeapProfile(conn)
 	case signal.CPUProfile:

--- a/cmd.go
+++ b/cmd.go
@@ -19,7 +19,6 @@ var cmds = map[string](func(addr net.TCPAddr) error){
 	"stack":      stackTrace,
 	"gc":         gc,
 	"memstats":   memStats,
-	"version":    version,
 	"pprof-heap": pprofHeap,
 	"pprof-cpu":  pprofCPU,
 	"stats":      stats,
@@ -37,10 +36,6 @@ func gc(addr net.TCPAddr) error {
 
 func memStats(addr net.TCPAddr) error {
 	return cmdWithPrint(addr, signal.MemStats)
-}
-
-func version(addr net.TCPAddr) error {
-	return cmdWithPrint(addr, signal.Version)
 }
 
 func pprofHeap(addr net.TCPAddr) error {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ Commands:
     stack       Prints the stack trace.
     gc          Runs the garbage collector and blocks until successful.
     memstats    Prints the allocation and garbage collection stats.
-    version     Prints the Go version used to build the program.
     stats       Prints the vital runtime stats.
     help        Prints this help text.
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -15,9 +15,6 @@ const (
 	// MemStats reports memory stats.
 	MemStats = byte(0x3)
 
-	// Version prints the Go version.
-	Version = byte(0x4)
-
 	// HeapProfile starts `go tool pprof` with the current memory profile.
 	HeapProfile = byte(0x5)
 


### PR DESCRIPTION
Finishes up #22

Remove subcommand `version` after @rsc's goversion
was bundled by @rakyll as an internal package in
112843115d59884316129929d302344caed7855e,
thus we no longer need to expose `version`.