### PR TITLE
agent: don't close on interrupt by default

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,7 +43,7 @@ type Options struct {
 	// Optional.
 	Addr string
 
-	// ShutdownCleanup utomatically cleans up resources if the
+	// ShutdownCleanup automatically cleans up resources if the
 	// running process receives an interrupt. Otherwise, users
 	// can call Close before shutting down.
 	// Optional.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,10 +43,11 @@ type Options struct {
 	// Optional.
 	Addr string
 
-	// NoShutdownCleanup tells the agent not to automatically cleanup
-	// resources if the running process receives an interrupt.
+	// ShutdownCleanup utomatically cleans up resources if the
+	// running process receives an interrupt. Otherwise, users
+	// can call Close before shutting down.
 	// Optional.
-	NoShutdownCleanup bool
+	ShutdownCleanup bool
 }
 
 // Listen starts the gops agent on a host process. Once agent started, users
@@ -58,13 +59,10 @@ type Options struct {
 // Note: The agent exposes an endpoint via a TCP connection that can be used by
 // any program on the system. Review your security requirements before starting
 // the agent.
-func Listen(opts *Options) error {
+func Listen(opts Options) error {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if opts == nil {
-		opts = &Options{}
-	}
 	if portfile != "" {
 		return fmt.Errorf("gops: agent already listening at: %v", listener.Addr())
 	}
@@ -77,7 +75,7 @@ func Listen(opts *Options) error {
 	if err != nil {
 		return err
 	}
-	if !opts.NoShutdownCleanup {
+	if opts.ShutdownCleanup {
 		gracefulShutdown()
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestListen(t *testing.T) {
-	err := Listen(nil)
+	err := Listen(Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +18,7 @@ func TestListen(t *testing.T) {
 }
 
 func TestAgentClose(t *testing.T) {
-	err := Listen(nil)
+	err := Listen(Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestAgentClose(t *testing.T) {
 }
 
 func TestAgentListenMultipleClose(t *testing.T) {
-	err := Listen(nil)
+	err := Listen(Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	if err := agent.Listen(agent.Options{
-		ShutdownCleanup: true, // automatically closes on interrupt.
+		ShutdownCleanup: true, // automatically closes on os.Interrupt
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -12,7 +12,9 @@ import (
 )
 
 func main() {
-	if err := agent.Listen(nil); err != nil {
+	if err := agent.Listen(agent.Options{
+		ShutdownCleanup: true, // automatically closes on interrupt.
+	}); err != nil {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Hour)


### PR DESCRIPTION
Users are having trouble that agent is stealing the notifier
by default. Make the feature more obvious by making it
non-default.