### PR TITLE
Keep tracefile if go binary is not found

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -65,11 +65,18 @@ func trace(addr net.TCPAddr) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpfile.Name())
+
 	if err := ioutil.WriteFile(tmpfile.Name(), out, 0); err != nil {
 		return err
 	}
 	fmt.Printf("Trace dump saved to: %s\n", tmpfile.Name())
+
+	// Keep tracefile if go binary is not found.
+	if _, err := exec.LookPath("go"); err != nil {
+		return nil
+	}
+	defer os.Remove(tmpfile.Name())
+
 	cmd := exec.Command("go", "tool", "trace", tmpfile.Name())
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
On our servers we have the go chain not installed and servers are behind a firewall (no tunnels possible)

With this pull request it would be possible to perform a trace and copy the trace file to a system where I have the go tool chain installed. There I could run `go tool trace <tracefile>` and analyze the trace file with the browser.

This could maybe also solve #44.