### PR TITLE
Keep trace and profile files when go tool chain is not available

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -65,11 +65,15 @@ func trace(addr net.TCPAddr) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpfile.Name())
 	if err := ioutil.WriteFile(tmpfile.Name(), out, 0); err != nil {
 		return err
 	}
 	fmt.Printf("Trace dump saved to: %s\n", tmpfile.Name())
+	// If go tool chain not found, stopping here and keep trace file.
+	if _, err := exec.LookPath("go"); err != nil {
+		return nil
+	}
+	defer os.Remove(tmpfile.Name())
 	cmd := exec.Command("go", "tool", "trace", tmpfile.Name())
 	cmd.Env = os.Environ()
 	cmd.Stdin = os.Stdin
@@ -92,10 +96,15 @@ func pprof(addr net.TCPAddr, p byte) error {
 		if len(out) == 0 {
 			return errors.New("failed to read the profile")
 		}
-		defer os.Remove(tmpDumpFile.Name())
 		if err := ioutil.WriteFile(tmpDumpFile.Name(), out, 0); err != nil {
 			return err
 		}
+		fmt.Printf("Profile dump saved to: %s\n", tmpDumpFile.Name())
+		// If go tool chain not found, stopping here and keep dump file.
+		if _, err := exec.LookPath("go"); err != nil {
+			return nil
+		}
+		defer os.Remove(tmpDumpFile.Name())
 	}
 	// Download running binary
 	tmpBinFile, err := ioutil.TempFile("", "binary")


### PR DESCRIPTION
On our servers we have the go tool chain not installed and the servers are behind a firewall (no tunnels possible).

With this pull request it would be possible to perform a trace or pprof and copy the trace file to a system where I have the go tool chain installed. There I could run `go tool trace <tracefile>` and analyze the trace file with the browser.

This could maybe also solve #44.

If the go tool chain is not available you get the following output:

```bash
$ gops pprof-heap localhost:41081            
Profile dump saved to: /tmp/profile936731714     
                                    
$ gops pprof-cpu localhost:41081                                                                                                   
Profiling CPU now, will take 30 secs...   
Profile dump saved to: /tmp/profile262095472    
                                     
$ gops trace localhost:41081                                                                                                       
Tracing now, will take 5 secs...          
Trace dump saved to: /tmp/trace774199372  
```