### PR TITLE
replace nil parm with empty Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import (
 )
 
 func main() {
-	if err := agent.Listen(nil); err != nil {
+	if err := agent.Listen(agent.Options{}); err != nil {
 		log.Fatal(err)
 	}
 	time.Sleep(time.Hour)


### PR DESCRIPTION
In the README the basic example show that a `nil` value can be passed to `agent.Listen`. This results in a compile error. 
This change is a simple change in the README to rather pass an empty `agent.Option`