### PR TITLE
Add usage synopsis in help message

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,11 @@ import (
 	"github.com/google/gops/goprocess"
 )
 
-const helpText = `Usage: gops is a tool to list and diagnose Go processes.
+const helpText = `gops is a tool to list and diagnose Go processes.
 
+Usage:
+
+    gops [command [pid|address:port]]
 
 Commands:
     stack       	Prints the stack trace.


### PR DESCRIPTION
I can't seem to remember the order in which the command and target goes. Probably a gops-newbie syndrome. So I think having the order spelled out in the help usage text helps.