### PR TITLE
Fixed data race in "FindAll" function. 

### DIFF
--- a/goprocess/gp_test.go
+++ b/goprocess/gp_test.go
@@ -1,0 +1,9 @@
+package goprocess
+
+import "testing"
+
+func BenchmarkFindAll(b *testing.B) {
+	for ii := 0; ii < b.N; ii++ {
+		_ = FindAll()
+	}
+}


### PR DESCRIPTION
There's a data race inside `gops/goprocess.FindAll` where the `results` list is written to in parallel. 
I introduced a goroutine which collects the results and writes to the `results` list in a thread safe manner. 