### PR TITLE
Check pid/addr of target process was specified for subcommands

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,9 @@ func main() {
 	if !ok {
 		usage("unknown subcommand")
 	}
+	if len(os.Args) < 3 {
+		usage("pid/addr of target process not specified")
+	}
 	addr, err := targetToAddr(os.Args[2])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't resolve addr or pid %v to TCPAddress: %v\n", os.Args[2], err)


### PR DESCRIPTION
`gops` panics if anything other than `help` was invoked without specifying the `pid`/`addr` of the target:

```
λ gops stats
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
        E:/Installs/go-tools/src/github.com/google/gops/main.go:68 +0x48a
```

This adds a check and prints the usage if it was not specified.

```
λ go run main.go cmd.go stats
gops: pid/addr of target process not specified
gops is a tool to list and diagnose Go processes.

        gops <cmd> <pid|addr> ...
        gops <pid> # displays process info

...

All commands require the agent running on the Go process.
Symbol "*" indicates the process runs the agent.
exit status 1
```