### PR TITLE
cmd: Check error returned by GetPort

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -184,6 +184,9 @@ func targetToAddr(target string) (*net.TCPAddr, error) {
 		return nil, fmt.Errorf("couldn't parse PID: %v", err)
 	}
 	port, err := internal.GetPort(pid)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get port for PID %s: %v", pid, err)
+	}
 	addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:"+port)
 	return addr, nil
 }


### PR DESCRIPTION
Before this change, error returned by internal.GetPort was
assigned to err variable, but this assignment was ineffectual
and error was ignored.