### PR TITLE
address breaking changes from xlab/treeprint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -54,7 +54,7 @@
   branch = "master"
   name = "github.com/xlab/treeprint"
   packages = ["."]
-  revision = "0f25eb5b1a4bacd40b67f48bce6248421a1e9c04"
+  revision = "d6fb6747feb6e7cfdc44682a024bddf87ef07ec2"
 
 [[projects]]
   branch = "master"

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func displayProcessTree() {
 		pstree[p.PPID] = append(pstree[p.PPID], p)
 	}
 	tree := treeprint.New()
-	treeprint.EdgeTypeStart = "..."
+	tree.SetValue("...")
 	seen := map[int]bool{}
 	for _, p := range ps {
 		constructProcessTree(p.PPID, p, seen, tree)

--- a/vendor/github.com/xlab/treeprint/struct.go
+++ b/vendor/github.com/xlab/treeprint/struct.go
@@ -99,7 +99,7 @@ func nameTree(tree Tree, v interface{}) error {
 		}
 		branch := tree.AddBranch(name)
 		if err := nameTree(branch, val.Interface()); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}
@@ -144,7 +144,7 @@ func valueTree(tree Tree, v interface{}) error {
 		}
 		branch := tree.AddBranch(name)
 		if err := valueTree(branch, val.Interface()); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}
@@ -175,7 +175,7 @@ func tagTree(tree Tree, v interface{}) error {
 		}
 		branch := tree.AddMetaBranch(filteredTag, name)
 		if err := tagTree(branch, val.Interface()); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}
@@ -206,7 +206,7 @@ func typeTree(tree Tree, v interface{}) error {
 		}
 		branch := tree.AddMetaBranch(typename, name)
 		if err := typeTree(branch, val.Interface()); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}
@@ -237,7 +237,7 @@ func typeSizeTree(tree Tree, v interface{}) error {
 		}
 		branch := tree.AddMetaBranch(typesize, name)
 		if err := typeSizeTree(branch, val.Interface()); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}
@@ -281,7 +281,7 @@ func metaTree(tree Tree, v interface{}, fmtFunc FmtFunc) error {
 			branch = tree.AddBranch(name)
 		}
 		if err := metaTree(branch, val.Interface(), fmtFunc); err != nil {
-			err := fmt.Errorf("%v on struct branch %s", name)
+			err := fmt.Errorf("%v on struct branch %s", err, name)
 			return err
 		}
 	}

--- a/vendor/github.com/xlab/treeprint/treeprint.go
+++ b/vendor/github.com/xlab/treeprint/treeprint.go
@@ -30,10 +30,14 @@ type Tree interface {
 	// FindByValue finds a node whose value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByValue(value Value) Tree
+	//  returns the last node of a tree
+	FindLastNode() Tree
 	// String renders the tree or subtree as a string.
 	String() string
 	// Bytes renders the tree or subtree as byteslice.
 	Bytes() []byte
+
+	SetValue(value Value)
 }
 
 type node struct {
@@ -41,6 +45,12 @@ type node struct {
 	Meta  MetaValue
 	Value Value
 	Nodes []*node
+}
+
+func (n *node) FindLastNode() Tree {
+	ns := n.Nodes
+	n = ns[len(ns)-1]
+	return n
 }
 
 func (n *node) AddNode(v Value) Tree {
@@ -117,7 +127,7 @@ func (n *node) Bytes() []byte {
 	level := 0
 	var levelsEnded []int
 	if n.Root == nil {
-		buf.WriteString(string(EdgeTypeStart))
+		buf.WriteString(fmt.Sprintf("%v",n.Value))
 		buf.WriteByte('\n')
 	} else {
 		edge := EdgeTypeMid
@@ -135,6 +145,10 @@ func (n *node) Bytes() []byte {
 
 func (n *node) String() string {
 	return string(n.Bytes())
+}
+
+func (n *node) SetValue(value Value){
+	n.Value = value
 }
 
 func printNodes(wr io.Writer,
@@ -182,12 +196,11 @@ func isEnded(levelsEnded []int, level int) bool {
 type EdgeType string
 
 var (
-	EdgeTypeStart EdgeType = "."
 	EdgeTypeLink  EdgeType = "│"
 	EdgeTypeMid   EdgeType = "├──"
 	EdgeTypeEnd   EdgeType = "└──"
 )
 
 func New() Tree {
-	return &node{}
+	return &node{Value: "."}
 }

--- a/vendor/github.com/xlab/treeprint/treeprint_test.go
+++ b/vendor/github.com/xlab/treeprint/treeprint_test.go
@@ -62,6 +62,23 @@ func TestLevel(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestNamedRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	tree := New()
+	tree.AddBranch("hello").AddNode("my friend").AddNode("lol")
+	tree.AddNode("world")
+	tree.SetValue("friends")
+	actual := tree.String()
+	expected := `friends
+├── hello
+│   ├── my friend
+│   └── lol
+└── world
+`
+	assert.Equal(expected, actual)
+}
+
 func TestDeepLevel(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Hi, in our internal testing tool we found that a PR of xlab/treeprint (https://github.com/xlab/treeprint/pull/6) which was merged might break gops in the future. The PR removed treeprint.EdgeTypeStart. To set the root node, we can now use SetValue(value Value) instead.

In this commit,

    dep ensure -update github.com/xlab/treeprint

was executed to update the library and then fix is applied.