### PR TITLE
Improve the help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,26 +23,24 @@ import (
 
 const helpText = `gops is a tool to list and diagnose Go processes.
 
-	gops <cmd> <pid|addr> ...
-	gops <pid> # displays process info
+Usage:
+  gops <cmd> <pid|addr> ...
+  gops <pid> # displays process info
+  gops help  # displays this help message
 
 Commands:
-    stack       	Prints the stack trace.
-    gc          	Runs the garbage collector and blocks until successful.
-    setgc	        Sets the garbage collection target percentage.
-    memstats    	Prints the allocation and garbage collection stats.
-    version     	Prints the Go version used to build the program.
-    stats       	Prints the vital runtime stats.
-    help        	Prints this help text.
-
-Profiling commands:
-    trace       	Runs the runtime tracer for 5 secs and launches "go tool trace".
-    pprof-heap  	Reads the heap profile and launches "go tool pprof".
-    pprof-cpu   	Reads the CPU profile and launches "go tool pprof".
-
+  stack      Prints the stack trace.
+  gc         Runs the garbage collector and blocks until successful.
+  setgc	     Sets the garbage collection target percentage.
+  memstats   Prints the allocation and garbage collection stats.
+  version    Prints the Go version used to build the program.
+  stats      Prints runtime stats.
+  trace      Runs the runtime tracer for 5 secs and launches "go tool trace".
+  pprof-heap Reads the heap profile and launches "go tool pprof".
+  pprof-cpu  Reads the CPU profile and launches "go tool pprof".
 
 All commands require the agent running on the Go process.
-Symbol "*" indicates the process runs the agent.`
+"*" indicates the process is running the agent.`
 
 // TODO(jbd): add link that explains the use of agent.
 


### PR DESCRIPTION
Avoid using tabs, remove help from "subcommands" list,
don't differentiate the profiling commands from others.