### PR TITLE
Check $XDG_CONFIG_HOME before falling to ~/.config

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -25,6 +25,11 @@ func ConfigDir() (string, error) {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("APPDATA"), "gops"), nil
 	}
+
+	if xdgConfigDir := os.Getenv("XDG_CONFIG_HOME"); xdgConfigDir != "" {
+		return filepath.Join(xdgConfigDir, "gops"), nil
+	}
+
 	homeDir := guessUnixHomeDir()
 	if homeDir == "" {
 		return "", errors.New("unable to get current user home directory: os/user lookup failed; $HOME is empty")


### PR DESCRIPTION
Just as [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) specifies:

>  `$XDG_CONFIG_HOME` defines the base directory relative to which user specific configuration files should be stored. If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME/.config` should be used. 

\*nix users should be able to use that, before needing to set `GOPS_CONFIG_DIR`