### PR TITLE
Use os.UserConfigDir for internal.ConfigDir if available

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -22,6 +22,10 @@ func ConfigDir() (string, error) {
 		return configDir, nil
 	}
 
+	if osUserConfigDir := getOSUserConfigDir(); osUserConfigDir != "" {
+		return osUserConfigDir, nil
+	}
+
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("APPDATA"), "gops"), nil
 	}

--- a/internal/internal_go1_13.go
+++ b/internal/internal_go1_13.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.13
+
+package internal
+
+import (
+	"os"
+)
+
+func getOSUserConfigDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return configDir
+}

--- a/internal/internal_lt_go1_13.go
+++ b/internal/internal_lt_go1_13.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.13
+
+package internal
+
+func getOSUserConfigDir() string {
+	return ""
+}


### PR DESCRIPTION
On Go ≥ 1.13 the os package has os.ConfigDir
(https://golang.org/pkg/os/#UserConfigDir) which returns the default
root directory to use for user-specific configuration data. Use this in
internal.ConfigDir if available, while still making sure that any
directory specified in GOPS_CONFIG_DIR takes precedence.