### PR TITLE
Fix configdir path and use correct path under windows

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -6,12 +6,12 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -23,7 +23,7 @@ func ConfigDir() (string, error) {
 	}
 
 	if osUserConfigDir := getOSUserConfigDir(); osUserConfigDir != "" {
-		return osUserConfigDir, nil
+		return filepath.Join(osUserConfigDir, "gops"), nil
 	}
 
 	if runtime.GOOS == "windows" {
@@ -54,7 +54,7 @@ func PIDFile(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/%d", gopsdir, pid), nil
+	return filepath.Join(gopsdir, strconv.Itoa(pid)), nil
 }
 
 func GetPort(pid int) (string, error) {


### PR DESCRIPTION
Two small fixes:
- adds the `gops`directory to the `osUserConfigDir`. So we use the correct directory.
- uses filepath.Join in `PIDFile()` so that gops works under windows. 