### PR TITLE
internal: add gops subdirectory in ConfigDir

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -23,7 +23,7 @@ func ConfigDir() (string, error) {
 	}
 
 	if osUserConfigDir := getOSUserConfigDir(); osUserConfigDir != "" {
-		return osUserConfigDir, nil
+		return filepath.Join(osUserConfigDir, "gops"), nil
 	}
 
 	if runtime.GOOS == "windows" {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -2,17 +2,27 @@ package internal
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestConfigDir(t *testing.T) {
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if g, w := filepath.Base(configDir), "gops"; g != w {
+		t.Errorf("ConfigDir: got base directory %q, want %q", g, w)
+	}
+
 	key := gopsConfigDirEnvKey
 	oldDir := os.Getenv(key)
 	defer os.Setenv(key, oldDir)
 
 	newDir := "foo-bar"
 	os.Setenv(key, newDir)
-	configDir, err := ConfigDir()
+	configDir, err = ConfigDir()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Use a subdirectory of the directory returned by os.UserConfigDir instead
of the UserConfigDir directly. This was missed in #103. Also add a test.

Based on a change by @42wim submitted in #107