### PR TITLE
internal: use filepath.Join in PIDFile

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -6,12 +6,12 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -54,7 +54,7 @@ func PIDFile(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/%d", gopsdir, pid), nil
+	return filepath.Join(gopsdir, strconv.Itoa(pid)), nil
 }
 
 func GetPort(pid int) (string, error) {


### PR DESCRIPTION
Use filepath.Join to create a path with correct path delimiters on
Windows.

Based on a change by @42wim submitted in #107