### PR TITLE
fix: EMFILE error on macOS Catalina

### DIFF
--- a/goprocess/gp.go
+++ b/goprocess/gp.go
@@ -27,6 +27,7 @@ type P struct {
 
 // FindAll returns all the Go processes currently running on this host.
 func FindAll() []P {
+	const concurrencyProcesses = 10 // limit the maximum number of concurrent reading process tasks
 	pss, err := ps.Processes()
 	if err != nil {
 		return nil
@@ -35,7 +36,7 @@ func FindAll() []P {
 	var wg sync.WaitGroup
 	wg.Add(len(pss))
 	found := make(chan P)
-	limitCh := make(chan struct{}, 10)
+	limitCh := make(chan struct{}, concurrencyProcesses)
 
 	for _, pr := range pss {
 		limitCh <- struct{}{}

--- a/goprocess/gp.go
+++ b/goprocess/gp.go
@@ -35,10 +35,13 @@ func FindAll() []P {
 	var wg sync.WaitGroup
 	wg.Add(len(pss))
 	found := make(chan P)
+	limitCh := make(chan struct{}, 10)
 
 	for _, pr := range pss {
+		limitCh <- struct{}{}
 		pr := pr
 		go func() {
+			defer func() { <-limitCh }()
 			defer wg.Done()
 
 			path, version, agent, ok, err := isGo(pr)

--- a/goprocess/gp_test.go
+++ b/goprocess/gp_test.go
@@ -1,41 +1,9 @@
 package goprocess
 
-import (
-	"os"
-	"sync"
-	"syscall"
-	"testing"
-
-	"github.com/keybase/go-ps"
-)
+import "testing"
 
 func BenchmarkFindAll(b *testing.B) {
 	for ii := 0; ii < b.N; ii++ {
 		_ = FindAll()
 	}
-}
-
-func TestEMFILE(t *testing.T) {
-	pss, err := ps.Processes()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(pss))
-
-	for _, pr := range pss {
-		pr := pr
-		go func() {
-			defer wg.Done()
-			_, _, _, _, err := isGo(pr)
-			if err != nil {
-				if e, ok := err.(*os.PathError); ok && e.Err == syscall.EMFILE {
-					t.Errorf("pid:%d got EMFILE error", pr.Pid())
-				}
-			}
-		}()
-	}
-
-	wg.Wait()
 }

--- a/goprocess/gp_test.go
+++ b/goprocess/gp_test.go
@@ -1,9 +1,41 @@
 package goprocess
 
-import "testing"
+import (
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/keybase/go-ps"
+)
 
 func BenchmarkFindAll(b *testing.B) {
 	for ii := 0; ii < b.N; ii++ {
 		_ = FindAll()
 	}
+}
+
+func TestEMFILE(t *testing.T) {
+	pss, err := ps.Processes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(pss))
+
+	for _, pr := range pss {
+		pr := pr
+		go func() {
+			defer wg.Done()
+			_, _, _, _, err := isGo(pr)
+			if err != nil {
+				if e, ok := err.(*os.PathError); ok && e.Err == syscall.EMFILE {
+					t.Errorf("pid:%d got EMFILE error", pr.Pid())
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
`go version go1.14.6 darwin/amd64`

https://github.com/google/gops/blob/983b7ba5c9fcb398bb823ef0a94889463099457f/goprocess/gp.go#L106

**goversion.ReadExe** will return EMFILE error because of no concurrency goroutines limit in:
https://github.com/google/gops/blob/983b7ba5c9fcb398bb823ef0a94889463099457f/goprocess/gp.go#L29

this error will make some Go processes unrecognized, this PR just add a concurrency limit to solve this problem