### PR TITLE
Fix formatting for multiple of 24 hours

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func fmtEtimeDuration(d time.Duration) string {
 	hours := d % (24 * time.Hour)
 	minutes := hours % time.Hour
 	seconds := math.Mod(minutes.Seconds(), 60)
-	var b bytes.Buffer
+	var b strings.Builder
 	if days > 0 {
 		fmt.Fprintf(&b, "%02d-", days)
 	}

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func fmtEtimeDuration(d time.Duration) string {
 	if days > 0 {
 		fmt.Fprintf(&b, "%02d-", days)
 	}
-	if hours/time.Hour > 0 {
+	if days > 0 || hours/time.Hour > 0 {
 		fmt.Fprintf(&b, "%02d:", hours/time.Hour)
 	}
 	fmt.Fprintf(&b, "%02d:", minutes/time.Minute)

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,10 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func Test_shortenVersion(t *testing.T) {
 	tests := []struct {
@@ -32,6 +35,45 @@ func Test_shortenVersion(t *testing.T) {
 		t.Run(tt.version, func(t *testing.T) {
 			if got := shortenVersion(tt.version); got != tt.want {
 				t.Errorf("shortenVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fmtEtimeDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{
+			want: "00:00",
+		},
+
+		{
+			d:    2*time.Minute + 5*time.Second + 400*time.Millisecond,
+			want: "02:05",
+		},
+		{
+			d:    1*time.Second + 500*time.Millisecond,
+			want: "00:02",
+		},
+		{
+			d:    2*time.Hour + 42*time.Minute + 12*time.Second,
+			want: "02:42:12",
+		},
+		{
+			d:    24 * time.Hour,
+			want: "01-00:00:00",
+		},
+		{
+			d:    24*time.Hour + 59*time.Minute + 59*time.Second,
+			want: "01-00:59:59",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.d.String(), func(t *testing.T) {
+			if got := fmtEtimeDuration(tt.d); got != tt.want {
+				t.Errorf("fmtEtimeDuration() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
In case a process has been running for a multiple of 24 hours, the
process runtime will be formatted as DD-MM:SS instead of DD-HH:MM:SS.
Fix this and add a test for `fmtEtimeDuration`.

Also switch from `bytes.Buffer` to `strings.Builder` in `fmtEtimeDuration`.