### PR TITLE
agent: allow to set SO_REUSEPORT on listening socket

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -54,6 +54,17 @@ func TestAgentListenMultipleClose(t *testing.T) {
 	Close()
 }
 
+func TestAgentListenReuseAddrAndPort(t *testing.T) {
+	err := Listen(Options{
+		Addr:                   "127.0.0.1:50000",
+		ReuseSocketAddrAndPort: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	Close()
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		val  uint64

--- a/agent/sockopt_unix.go
+++ b/agent/sockopt_unix.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !js,!plan9,!windows
+
+package agent
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// setsockoptReuseAddrAndPort sets the SO_REUSEADDR and SO_REUSEPORT socket
+// options on c's underlying socket in order to increase the chance to re-bind()
+// to the same address and port upon agent restart.
+func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
+	var soerr error
+	if err := c.Control(func(su uintptr) {
+		sock := int(su)
+		// Allow reuse of recently-used addresses. This socket option is
+		// set by default on listeners in Go's net package, see
+		// net.setDefaultSockopts.
+		soerr = unix.SetsockoptInt(sock, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if soerr != nil {
+			return
+		}
+		// Allow reuse of recently-used ports. This gives the agent a
+		// better chance to re-bind upon restarts.
+		soerr = unix.SetsockoptInt(sock, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	}); err != nil {
+		return err
+	}
+	return soerr
+}

--- a/agent/sockopt_unsupported.go
+++ b/agent/sockopt_unsupported.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build js,wasm plan9 windows
+
+package agent
+
+import "syscall"
+
+func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/shirou/gopsutil v2.20.4+incompatible
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/xlab/treeprint v1.0.0
-	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
+	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d
 	rsc.io/goversion v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xlab/treeprint v1.0.0 h1:J0TkWtiuYgtdlrkkrDLISYBQ92M+X5m4LrIIMKrbDTs=
 github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
-golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
-golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 rsc.io/goversion v1.2.0 h1:SPn+NLTiAG7w30IRK/DKp1BjvpWabYgxlLp/+kx5J8w=
 rsc.io/goversion v1.2.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=


### PR DESCRIPTION
Introduce `Option.SocketReuseAddrAndPort` which, if set, will lead to the
`SO_REUSEPORT` socket option being set on the listening socket on
Unix-like OSes. This also sets `SO_REUSEADDR` which is already the default
in `net.Listen` (see `net.setDefaultSockopts`).

Setting these options increases the chance to re-`bind()` to the same
address and port upon agent restart if `Options.Addr` is set.

