### PR TITLE
Add GitHub action for CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.12, 1.13, 1.14, 1.15, 1.16]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Check formatting
+      if: matrix.go-version == '1.16' && matrix.platform == 'ubuntu-latest'
+      run: diff -u <(echo -n) <(go fmt $(go list ./...))
+
+    - name: Check module vendoring
+      if: matrix.go-version == '1.16' && matrix.platform == 'ubuntu-latest'
+      run: |
+        go mod tidy
+        go mod vendor
+        git diff --exit-code || exit 1
+
+    - name: Run unit tests
+      run: go test -v ./...


### PR DESCRIPTION
This extends the testing currently done in CircleCI:

* run CI on macOS in addition to Linux and Windows
* testing with multiple Go versions (1.12 through 1.16), not just Go
  1.12 like CircleCI
* checks that the code is properly `gofmt`'ed
* checks proper module vendoring