### PR TITLE
agent: use filepath.Join to construct portfile path

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"os"
 	gosignal "os/signal"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
@@ -113,7 +114,7 @@ func Listen(opts Options) error {
 		return err
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	portfile = fmt.Sprintf("%s/%d", gopsdir, os.Getpid())
+	portfile = filepath.Join(gopsdir, strconv.Itoa(os.Getpid()))
 	err = ioutil.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
 	if err != nil {
 		return err


### PR DESCRIPTION
If `gopsdir` contains a trailing slash, the resulting `portfile` path will
contain a trailing double slash which might lead to problems in some
circumstances. Moreover iut could also be problematic on platforms where
other path separators are used (e.g. Windows).

Fix this by using `filepath.Join` to construct the path.