### PR TITLE
Fix CPU usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The output displays:
 
 Note that processes running the agent are marked with `*` next to the PID (e.g. `4132*`).
 
-#### $ gops \<pid\>
+#### $ gops \<pid\> [duration]
 
 To report more information about a process, run `gops` followed by a PID:
 
@@ -89,6 +89,24 @@ parent PID:	5985
 threads:	27
 memory usage:	0.199%
 cpu usage:	0.139%
+username:	jbd
+cmd+args:	/Applications/Splice.app/Contents/Resources/Splice Helper.app/Contents/MacOS/Splice Helper -pid 5985
+local/remote:	127.0.0.1:56765 <-> :0 (LISTEN)
+local/remote:	127.0.0.1:56765 <-> 127.0.0.1:50955 (ESTABLISHED)
+local/remote:	100.76.175.164:52353 <-> 54.241.191.232:443 (ESTABLISHED)
+```
+
+If an optional duration is specified in the format as expected by
+[`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration), the CPU
+usage for the given time period is reported in addition:
+
+```sh
+$ gops <pid> 2s
+parent PID:	5985
+threads:	27
+memory usage:	0.199%
+cpu usage:	0.139%
+cpu usage (2s):	0.271%
 username:	jbd
 cmd+args:	/Applications/Splice.app/Contents/Resources/Splice Helper.app/Contents/MacOS/Splice Helper -pid 5985
 local/remote:	127.0.0.1:56765 <-> :0 (LISTEN)
@@ -199,4 +217,3 @@ gops allows you to start the runtime tracer for 5 seconds and examine the result
 ```sh
 $ gops trace (<pid>|<addr>)
 ```
-

--- a/README.md
+++ b/README.md
@@ -79,23 +79,21 @@ The output displays:
 
 Note that processes running the agent are marked with `*` next to the PID (e.g. `4132*`).
 
-#### $ gops \<pid\> [seconds] 
+#### $ gops \<pid\>
 
-To report more information about a process, run `gops` following by a PID:
-> If set the seconds arg, the percent of the CPU time this process uses within given time duration will be reported.
+To report more information about a process, run `gops` followed by a PID:
 
 ```sh
 $ gops <pid>
-parent PID:	  5985
-threads:	  27
-memory usage:	  0.199%
-cpu usage(all): 0.139%
-cpu usage(1s):	  19.5% # if seconds provided
-username:	  jbd
-cmd+args:	  /Applications/Splice.app/Contents/Resources/Splice Helper.app/Contents/MacOS/Splice   Helper -pid 5985
-local/remote:	  127.0.0.1:56765 <-> :0 (LISTEN)
-local/remote:	  127.0.0.1:56765 <-> 127.0.0.1:50955 (ESTABLISHED)
-local/remote:	  100.76.175.164:52353 <-> 54.241.191.232:443 (ESTABLISHED)
+parent PID:	5985
+threads:	27
+memory usage:	0.199%
+cpu usage:	0.139%
+username:	jbd
+cmd+args:	/Applications/Splice.app/Contents/Resources/Splice Helper.app/Contents/MacOS/Splice Helper -pid 5985
+local/remote:	127.0.0.1:56765 <-> :0 (LISTEN)
+local/remote:	127.0.0.1:56765 <-> 127.0.0.1:50955 (ESTABLISHED)
+local/remote:	100.76.175.164:52353 <-> 54.241.191.232:443 (ESTABLISHED)
 ```
 
 #### $ gops tree

--- a/main.go
+++ b/main.go
@@ -55,11 +55,15 @@ func main() {
 	// See if it is a PID.
 	pid, err := strconv.Atoi(cmd)
 	if err == nil {
-		var interval int
+		var period time.Duration
 		if len(os.Args) >= 3 {
-			interval, _ = strconv.Atoi(os.Args[2])
+			period, err = time.ParseDuration(os.Args[2])
+			if err != nil {
+				secs, _ := strconv.Atoi(os.Args[2])
+				period = time.Duration(secs) * time.Second
+			}
 		}
-		processInfo(pid, interval)
+		processInfo(pid, period)
 		return
 	}
 
@@ -131,7 +135,7 @@ func processes() {
 	}
 }
 
-func processInfo(pid, interval int) {
+func processInfo(pid int, period time.Duration) {
 	p, err := process.NewProcess(int32(pid))
 	if err != nil {
 		log.Fatalf("Cannot read process info: %v", err)
@@ -148,9 +152,9 @@ func processInfo(pid, interval int) {
 	if v, err := p.CPUPercent(); err == nil {
 		fmt.Printf("cpu usage:\t%.3f%%\n", v)
 	}
-	if interval > 0 {
-		if v, err := cpuPercentWithinTime(p, time.Second*time.Duration(interval)); err == nil {
-			fmt.Printf("cpu usage (%ds):\t%.3f%%\n", interval, v)
+	if period > 0 {
+		if v, err := cpuPercentWithinTime(p, period); err == nil {
+			fmt.Printf("cpu usage (%v):\t%.3f%%\n", period, v)
 		}
 	}
 	if v, err := p.Username(); err == nil {

--- a/main.go
+++ b/main.go
@@ -146,11 +146,11 @@ func processInfo(pid, interval int) {
 		fmt.Printf("memory usage:\t%.3f%%\n", v)
 	}
 	if v, err := p.CPUPercent(); err == nil {
-		fmt.Printf("cpu usage(all):\t%.3f%%\n", v)
+		fmt.Printf("cpu usage:\t%.3f%%\n", v)
 	}
 	if interval > 0 {
 		if v, err := cpuPercentWithinTime(p, time.Second*time.Duration(interval)); err == nil {
-			fmt.Printf("cpu usage(%ds):\t%.3f%%\n", interval, v)
+			fmt.Printf("cpu usage (%ds):\t%.3f%%\n", interval, v)
 		}
 	}
 	if v, err := p.Username(); err == nil {


### PR DESCRIPTION
Two followups for #143:

```
    Restore CPU usage report format

    Commit 78435f89 changed the existing output format for the CPU usage
    from `cpu usage:` to `cpu usage (all):`.

    This might break existing scripts relying on this format. Revert that
    part of the change and only report the CPU usage for the given period
    with a suffix:

    cpu usage:      0.087%
    cpu usage (1s): 1.42%
```

and

```
    Allow to specify CPU usage period as duration string

    The current implementation assumes the given duration in seconds.
    Instead, also allow to specify a duration in the format as expected by
    `time.ParseDuration` and use that if found. If a plain integer is
    specified, it is still parsed as a duration in seconds.
```