### PR TITLE
Error out when the given duration is negative

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,6 +136,9 @@ func processes() {
 }
 
 func processInfo(pid int, period time.Duration) {
+	if period < 0 {
+		log.Fatalf("Cannot process with negative duration: %v", period)
+	}
 	p, err := process.NewProcess(int32(pid))
 	if err != nil {
 		log.Fatalf("Cannot read process info: %v", err)
@@ -152,10 +155,8 @@ func processInfo(pid int, period time.Duration) {
 	if v, err := p.CPUPercent(); err == nil {
 		fmt.Printf("cpu usage:\t%.3f%%\n", v)
 	}
-	if period > 0 {
-		if v, err := cpuPercentWithinTime(p, period); err == nil {
-			fmt.Printf("cpu usage (%v):\t%.3f%%\n", period, v)
-		}
+	if v, err := cpuPercentWithinTime(p, period); err == nil {
+		fmt.Printf("cpu usage (%v):\t%.3f%%\n", period, v)
 	}
 	if v, err := p.Username(); err == nil {
 		fmt.Printf("username:\t%v\n", v)

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func processes() {
 
 func processInfo(pid int, period time.Duration) {
 	if period < 0 {
-		log.Fatalf("Cannot process with negative duration: %v", period)
+		log.Fatalf("Cannot determine CPU usage for negative duration %v", period)
 	}
 	p, err := process.NewProcess(int32(pid))
 	if err != nil {


### PR DESCRIPTION
Fixes: #154 

Validate `processInfo` period & log a fatal error in the case of negative duration.

Now gops exits and returns a fatal error in the case when the user supplies a negative duration to `gops <pid> <duration>` instead of defaulting to 0 as shown below.

Previously:

```
$ gops 21794 -1.3s
parent PID:     21703
threads:        7
memory usage:   0.040%
cpu usage:      0.000%
username:       admin
cmd+args:       /tmp/go-build3005809368/b001/exe/main
elapsed time:   15:39
local/remote:   127.0.0.1:38793 <-> 0.0.0.0:0 (LISTEN)
```

Now:

```
$ go build && ./gops 21794 -1s  
2021/11/10 18:18:26 Cannot process with negative duration: -1s
```

Note:

In an attempt to validate the duration values, I skipped over validating floats as internally they get converted to the appropriate duration. for example `0.5s` internally gets converted to `500ms`
