### PR TITLE
Extend `gops trace` to allow duration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,10 @@ $ gops pprof-heap (<pid>|<addr>)
 
 ##### Execution trace
 
-gops allows you to start the runtime tracer for 5 seconds and examine the results.
+gops allows you to start the runtime tracer for a specified duration and
+examine the results.
 
 ```sh
-$ gops trace (<pid>|<addr>)
+$ gops trace (<pid>|<addr>) 90s
+Tracing now, will take 1m30s...
 ```

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ Commands:
   memstats   Prints the allocation and garbage collection stats.
   version    Prints the Go version used to build the program.
   stats      Prints runtime stats.
-  trace      Runs the runtime tracer for 5 secs and launches "go tool trace".
+  trace      Runs the runtime tracer and launches "go tool trace".
   pprof-heap Reads the heap profile and launches "go tool pprof".
   pprof-cpu  Reads the CPU profile and launches "go tool pprof".
 


### PR DESCRIPTION
`gops trace :port 10m` will now run a trace for 10 minutes,
as opposed to always doing 5 seconds.

For backwards compatibility both server and the client
default to 5s if nothing is specified.