### PR TITLE
Bump minimum Go version to 1.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # Minimum supported version (1.12) and the latest two
-        go-version: [1.12, 1.17, 1.18]
+        # Minimum supported version (1.13) and the latest two
+        go-version: [1.13, 1.17, 1.18]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/gops
 
-go 1.12
+go 1.13
 
 require (
 	github.com/go-ole/go-ole v1.2.6-0.20210915003542-8b1f7f90f6b1 // indirect


### PR DESCRIPTION
This will allow to update github.com/shirou/gopsutil which requires at
least Go 1.13.