### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled


### PR DESCRIPTION
Dependabot will automatically open PRs to bump Go modules and GitHub
actions. See [1] for details.

[1] https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dep