### PR TITLE
internal: remove redundant environment variable checks in ConfigDir

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 )
@@ -24,14 +23,6 @@ func ConfigDir() (string, error) {
 
 	if userConfigDir, err := os.UserConfigDir(); err == nil {
 		return filepath.Join(userConfigDir, "gops"), nil
-	}
-
-	if runtime.GOOS == "windows" {
-		return filepath.Join(os.Getenv("APPDATA"), "gops"), nil
-	}
-
-	if xdgConfigDir := os.Getenv("XDG_CONFIG_HOME"); xdgConfigDir != "" {
-		return filepath.Join(xdgConfigDir, "gops"), nil
 	}
 
 	homeDir := guessUnixHomeDir()


### PR DESCRIPTION
os.UserConfigDir will already check the AppData environment variable on
Windows (environment variable names are case-insensitive on Windows):
https://cs.opensource.google/go/go/+/release-branch.go1.19:src/os/file.go;l=461-465
and the XDG_CONFIG_HOME environment variable on Unix operating systems:
https://cs.opensource.google/go/go/+/release-branch.go1.19:src/os/file.go;l=481-489