### PR TITLE
cmd/shared: add 'off' option to setgc

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ The following command sets it to 10%:
 ``` sh
 $ gops setgc (<pid>|<addr>) 10
 ```
+The following command turns off the garbage collector:
+
+```sh
+$ gops setgc (<pid>|<addr>) off
+```
 
 #### $ gops version (\<pid\>|\<addr\>)
 

--- a/internal/cmd/shared.go
+++ b/internal/cmd/shared.go
@@ -129,7 +129,7 @@ func setGC(addr net.TCPAddr, params []string) error {
 	}
 	var (
 		perc int64
-		err error
+		err  error
 	)
 	if strings.ToLower(params[0]) == "off" {
 		perc = -1

--- a/internal/cmd/shared.go
+++ b/internal/cmd/shared.go
@@ -43,7 +43,7 @@ func AgentCommands() []*cobra.Command {
 		},
 		{
 			name:  "setgc",
-			short: "Sets the garbage collection target percentage.",
+			short: "Sets the garbage collection target percentage. To completely stop GC, set to 'off'",
 			fn:    setGC,
 		},
 		{
@@ -127,9 +127,17 @@ func setGC(addr net.TCPAddr, params []string) error {
 	if len(params) != 1 {
 		return errors.New("missing gc percentage")
 	}
-	perc, err := strconv.ParseInt(params[0], 10, strconv.IntSize)
-	if err != nil {
-		return err
+	var (
+		perc int64
+		err error
+	)
+	if strings.ToLower(params[0]) == "off" {
+		perc = -1
+	} else {
+		perc, err = strconv.ParseInt(params[0], 10, strconv.IntSize)
+		if err != nil {
+			return err
+		}
 	}
 	buf := make([]byte, binary.MaxVarintLen64)
 	binary.PutVarint(buf, perc)


### PR DESCRIPTION
To stop GC completely, debug.SetGCPercentage needs to receive a negative integer. Passing a negative integer is cumbersome: $ gops setgc <pid> -- -1

This commit adds a more user-friendly way to achieve that: $ gops setgc <pid> off

This behavior is aligned with that of the GOGC env variable, where negative or "off" can be set to stop the GC.

fixes #200 