### PR TITLE
replace io/ioutil usages with io and os

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	gosignal "os/signal"
@@ -115,7 +114,7 @@ func Listen(opts Options) error {
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	portfile = filepath.Join(gopsdir, strconv.Itoa(os.Getpid()))
-	err = ioutil.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	err = os.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/goprocess/goprocess_test.go
+++ b/goprocess/goprocess_test.go
@@ -1,7 +1,6 @@
 package goprocess
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -72,17 +71,17 @@ func TestFindAll(t *testing.T) {
 				if runtime.GOOS != "linux" {
 					t.Skip()
 				}
-				tempDir, err := ioutil.TempDir("", "")
+				tempDir, err := os.MkdirTemp("", "")
 				if err != nil {
 					t.Errorf("failed to create temp dir: %v", err)
 				}
 				defer os.RemoveAll(tempDir)
 				for _, p := range tc.input {
 					os.Mkdir(filepath.Join(tempDir, strconv.Itoa(int(p.Pid))), 0o755)
-					ioutil.WriteFile(filepath.Join(tempDir, strconv.Itoa(int(p.Pid)), "stat"), []byte(
+					os.WriteFile(filepath.Join(tempDir, strconv.Itoa(int(p.Pid)), "stat"), []byte(
 						`1440024 () R 0 1440024 0 34821 1440024 4194304 134 0 0 0 0 0 0 0 20 0 1 0 95120609 6746112 274 18446744073709551615 94467689938944 94467690036601 140724224197808 0 0 0 0 0 0 0 0 0 17 11 0 0 0 0 0 94467690068048 94467690071296 94467715629056 140724224199226 140724224199259 140724224199259 140724224204780 0`,
 					), 0o644)
-					ioutil.WriteFile(filepath.Join(tempDir, strconv.Itoa(int(p.Pid)), "status"), []byte(
+					os.WriteFile(filepath.Join(tempDir, strconv.Itoa(int(p.Pid)), "status"), []byte(
 						`Name:
 Umask:  0022
 State:  R (running)

--- a/internal/cmd/shared.go
+++ b/internal/cmd/shared.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -179,11 +178,11 @@ func trace(addr net.TCPAddr, _ []string) error {
 	if len(out) == 0 {
 		return errors.New("nothing has traced")
 	}
-	tmpfile, err := ioutil.TempFile("", "trace")
+	tmpfile, err := os.CreateTemp("", "trace")
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(tmpfile.Name(), out, 0); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), out, 0); err != nil {
 		return err
 	}
 	fmt.Printf("Trace dump saved to: %s\n", tmpfile.Name())
@@ -201,7 +200,7 @@ func trace(addr net.TCPAddr, _ []string) error {
 }
 
 func pprof(addr net.TCPAddr, p byte, prefix string) error {
-	tmpDumpFile, err := ioutil.TempFile("", prefix+"_profile")
+	tmpDumpFile, err := os.CreateTemp("", prefix+"_profile")
 	if err != nil {
 		return err
 	}
@@ -213,7 +212,7 @@ func pprof(addr net.TCPAddr, p byte, prefix string) error {
 		if len(out) == 0 {
 			return errors.New("failed to read the profile")
 		}
-		if err := ioutil.WriteFile(tmpDumpFile.Name(), out, 0); err != nil {
+		if err := os.WriteFile(tmpDumpFile.Name(), out, 0); err != nil {
 			return err
 		}
 		fmt.Printf("Profile dump saved to: %s\n", tmpDumpFile.Name())
@@ -224,7 +223,7 @@ func pprof(addr net.TCPAddr, p byte, prefix string) error {
 		defer os.Remove(tmpDumpFile.Name())
 	}
 	// Download running binary
-	tmpBinFile, err := ioutil.TempFile("", "binary")
+	tmpBinFile, err := os.CreateTemp("", "binary")
 	if err != nil {
 		return err
 	}
@@ -237,7 +236,7 @@ func pprof(addr net.TCPAddr, p byte, prefix string) error {
 			return errors.New("failed to read the binary")
 		}
 		defer os.Remove(tmpBinFile.Name())
-		if err := ioutil.WriteFile(tmpBinFile.Name(), out, 0); err != nil {
+		if err := os.WriteFile(tmpBinFile.Name(), out, 0); err != nil {
 			return err
 		}
 	}
@@ -294,7 +293,7 @@ func cmd(addr net.TCPAddr, c byte, params ...byte) ([]byte, error) {
 		return nil, fmt.Errorf("couldn't get port by PID: %v", err)
 	}
 
-	all, err := ioutil.ReadAll(conn)
+	all, err := io.ReadAll(conn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -6,7 +6,6 @@ package internal
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -53,7 +52,7 @@ func GetPort(pid int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	b, err := ioutil.ReadFile(portfile)
+	b, err := os.ReadFile(portfile)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
package io/ioutil was deprecated as of go1.16 and its functions now directly call io and os functions. It is recommended to use these implementations in new code.