### PR TITLE
don't fail if can't save config due to EROFS or EPERM

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -145,12 +146,18 @@ func saveConfig(opts Options, port int) (err error) {
 	}
 
 	err = os.MkdirAll(gopsdir, os.ModePerm)
+	if errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EPERM) { // ignore and work in remote mode only
+		return nil
+	}
 	if err != nil {
 		return err
 	}
 
 	portfile = filepath.Join(gopsdir, strconv.Itoa(os.Getpid()))
 	err = os.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	if errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EPERM) { // ignore and work in remote mode only
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -94,24 +94,9 @@ func Listen(opts Options) (err error) {
 	if err != nil {
 		return err
 	}
+
 	port := listener.Addr().(*net.TCPAddr).Port
-
-	gopsdir := opts.ConfigDir
-	if gopsdir == "" {
-		cfgDir, err := internal.ConfigDir()
-		if err != nil {
-			return err
-		}
-		gopsdir = cfgDir
-	}
-
-	err = os.MkdirAll(gopsdir, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	portfile = filepath.Join(gopsdir, strconv.Itoa(os.Getpid()))
-	err = os.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	err = saveConfig(opts, port)
 	if err != nil {
 		return err
 	}
@@ -147,6 +132,30 @@ func listen(l net.Listener) {
 		}
 		fd.Close()
 	}
+}
+
+func saveConfig(opts Options, port int) (err error) {
+	gopsdir := opts.ConfigDir
+	if gopsdir == "" {
+		cfgDir, err := internal.ConfigDir()
+		if err != nil {
+			return err
+		}
+		gopsdir = cfgDir
+	}
+
+	err = os.MkdirAll(gopsdir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	portfile = filepath.Join(gopsdir, strconv.Itoa(os.Getpid()))
+	err = os.WriteFile(portfile, []byte(strconv.Itoa(port)), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func gracefulShutdown() {


### PR DESCRIPTION
In k8s environments one can have read-only file system or no home directory at all (distroless env),
so don't fail start as we have remote listener anyway.