### PR TITLE
add "setmemlimit" command

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -279,6 +279,17 @@ func handle(conn io.ReadWriter, msg []byte) error {
 			return err
 		}
 		fmt.Fprintf(conn, "New GC percent set to %v. Previous value was %v.\n", perc, debug.SetGCPercent(int(perc)))
+	case signal.SetMemLimit:
+		limit, err := binary.ReadVarint(bufio.NewReader(conn))
+		if err != nil {
+			return err
+		}
+		previous, err := setMemoryLimit(limit)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(conn, "New memory limit set to %v. Previous value was %v.\n",
+			formatBytes(uint64(limit)), formatBytes(uint64(previous)))
 	}
 	return nil
 }

--- a/agent/memory_limit.go
+++ b/agent/memory_limit.go
@@ -1,0 +1,14 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.19
+// +build go1.19
+
+package agent
+
+import "runtime/debug"
+
+func setMemoryLimit(limit int64) (int64, error) {
+	return debug.SetMemoryLimit(limit), nil
+}

--- a/agent/memory_limit_lt1.19.go
+++ b/agent/memory_limit_lt1.19.go
@@ -1,0 +1,20 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.19
+// +build !go1.19
+
+package agent
+
+import (
+	"errors"
+	"math"
+)
+
+func setMemoryLimit(limit int64) (int64, error) {
+	if limit < 0 {
+		return math.MaxInt64
+	}
+	return 0, errors.New("memory limit not supported on Go versions before 1.19")
+}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -35,4 +35,7 @@ const (
 
 	// SetGCPercent sets the garbage collection target percentage.
 	SetGCPercent = byte(0x10)
+
+	// SetMemLimit sets the memory limit. (Go 1.19+)
+	SetMemLimit = byte(0x11)
 )


### PR DESCRIPTION
This patch adds "setmemlimit" command for utilizing new memory limit feature in Go 1.19+.