### PR TITLE
Remove some named returns

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -75,7 +75,7 @@ type Options struct {
 // Note: The agent exposes an endpoint via a TCP connection that can be used by
 // any program on the system. Review your security requirements before starting
 // the agent.
-func Listen(opts Options) (err error) {
+func Listen(opts Options) error {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -87,10 +87,13 @@ func Listen(opts Options) (err error) {
 	if addr == "" {
 		addr = defaultAddr
 	}
+
 	var lc net.ListenConfig
 	if opts.ReuseSocketAddrAndPort {
 		lc.Control = setReuseAddrAndPortSockopts
 	}
+
+	var err error
 	listener, err = lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {
 		return err
@@ -135,7 +138,7 @@ func listen(l net.Listener) {
 	}
 }
 
-func saveConfig(opts Options, port int) (err error) {
+func saveConfig(opts Options, port int) error {
 	gopsdir := opts.ConfigDir
 	if gopsdir == "" {
 		cfgDir, err := internal.ConfigDir()
@@ -145,7 +148,7 @@ func saveConfig(opts Options, port int) (err error) {
 		gopsdir = cfgDir
 	}
 
-	err = os.MkdirAll(gopsdir, os.ModePerm)
+	err := os.MkdirAll(gopsdir, os.ModePerm)
 	if errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.EPERM) { // ignore and work in remote mode only
 		return nil
 	}

--- a/goprocess/goprocess.go
+++ b/goprocess/goprocess.go
@@ -94,7 +94,7 @@ func findAll(pss []*process.Process, isGo isGoFunc, concurrencyLimit int) []P {
 }
 
 // Find finds info about the process identified with the given PID.
-func Find(pid int) (p P, ok bool, err error) {
+func Find(pid int) (P, bool, error) {
 	pr, err := process.NewProcess(int32(pid))
 	if err != nil {
 		return P{}, false, err


### PR DESCRIPTION
Named returns should only be used with naked returns, or a deferred function. And in general are better avoided