### PR TITLE
add stack-legacy command to dump call traces in legacy format

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -208,6 +208,8 @@ func formatBytes(val uint64) string {
 
 func handle(conn io.ReadWriter, msg []byte) error {
 	switch msg[0] {
+	case signal.StackTraceLegacy:
+		return pprof.Lookup("goroutine").WriteTo(conn, 1)
 	case signal.StackTrace:
 		return pprof.Lookup("goroutine").WriteTo(conn, 2)
 	case signal.GC:

--- a/internal/cmd/shared.go
+++ b/internal/cmd/shared.go
@@ -36,6 +36,11 @@ func AgentCommands() []*cobra.Command {
 			fn:    stackTrace,
 		},
 		{
+			name:  "stack-legacy",
+			short: "Prints the stack trace in legacy mode but with labels.",
+			fn:    stackTraceLegacy,
+		},
+		{
 			name:  "gc",
 			short: "Runs the garbage collector and blocks until successful.",
 			fn:    gc,
@@ -145,6 +150,10 @@ func setGC(addr net.TCPAddr, params []string) error {
 
 func stackTrace(addr net.TCPAddr, _ []string) error {
 	return cmdWithPrint(addr, signal.StackTrace)
+}
+
+func stackTraceLegacy(addr net.TCPAddr, _ []string) error {
+	return cmdWithPrint(addr, signal.StackTraceLegacy)
 }
 
 func gc(addr net.TCPAddr, _ []string) error {

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -35,4 +35,7 @@ const (
 
 	// SetGCPercent sets the garbage collection target percentage.
 	SetGCPercent = byte(0x10)
+
+	// StackTraceLegacy represents a command to print stack trace in a legacy format (but it includes labels).
+	StackTraceLegacy = byte(0x11)
 )


### PR DESCRIPTION
Unfortunately legacy format is more helpful in debug as it dumps goroutine labels. 'gops stack' doesn't dump them.

Golang issue: https://github.com/golang/go/issues/63712