### PR TITLE
Bump minimum Go version to 1.18, test on latest supported releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # Minimum supported version (1.17) and the latest two
-        go-version: ['1.17', '1.19', '1.20']
+        # Minimum supported version (1.18) and the latest two
+        go-version: ['1.18', '1.21', '1.22']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check formatting
-      if: matrix.go-version == '1.20' && matrix.platform == 'ubuntu-latest'
+      if: matrix.go-version == '1.22' && matrix.platform == 'ubuntu-latest'
       run: diff -u <(echo -n) <(go fmt $(go list ./...))
 
     - name: Run unit tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/gops
 
-go 1.17
+go 1.18
 
 require (
 	github.com/shirou/gopsutil/v3 v3.24.3


### PR DESCRIPTION
Bump the minimum supported Go version to 1.18 in go.mod. Also make sure CI is testing against the latest two versions supported upstream, currently 1.21 and 1.22.